### PR TITLE
osdoc

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -107,14 +107,21 @@ export default defineConfig({
           items: [
             { text: 'Overview', link: '/kubernetes/' },
             {
-              text: 'Architecture',
-              link: '/operating-system/kubernetes/architecture',
+              text: 'OpenStack Cluster',
+              items: [
+                { text: 'Architecture', link: '/operating-system/kubernetes/architecture' },
+                { text: 'Bootstrap Procedure', link: '/operating-system/kubernetes/bootstrap' },
+                { text: 'Adding a Node', link: '/openstack/adding-a-node' },
+              ],
             },
             {
-              text: 'Bootstrap Procedure',
-              link: '/operating-system/kubernetes/bootstrap',
+              text: 'Management Cluster',
+              items: [
+                { text: 'Overview', link: '/gitops/fluxcd/management-cluster' },
+                { text: 'Bootstrap', link: '/bootstrap/management-cluster' },
+                { text: 'CAPI Pivot', link: '/gitops/fluxcd/capi-pivot' },
+              ],
             },
-            { text: 'Adding a Node', link: '/openstack/adding-a-node' },
           ],
         },
         {

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -27,6 +27,8 @@ export default defineConfig({
       { text: 'Home', link: '/' },
       { text: 'Onboarding', link: '/onboarding/' },
       { text: 'Operating System', link: '/operating-system/' },
+      { text: 'Kubernetes', link: '/kubernetes/' },
+      { text: 'OpenStack', link: '/openstack/' },
       { text: 'GitOps', link: '/gitops/' },
       { text: 'Infrastructure Notes', link: '/infrastructure-notes' },
     ],
@@ -98,6 +100,28 @@ export default defineConfig({
                 },
               ],
             },
+          ],
+        },
+        {
+          text: 'Kubernetes',
+          items: [
+            { text: 'Overview', link: '/kubernetes/' },
+            {
+              text: 'Architecture',
+              link: '/operating-system/kubernetes/architecture',
+            },
+            {
+              text: 'Bootstrap Procedure',
+              link: '/operating-system/kubernetes/bootstrap',
+            },
+            { text: 'Adding a Node', link: '/openstack/adding-a-node' },
+          ],
+        },
+        {
+          text: 'OpenStack',
+          items: [
+            { text: 'Overview', link: '/openstack/' },
+            { text: 'Adding a Node', link: '/openstack/adding-a-node' },
           ],
         },
         {

--- a/bootstrap/openstack-cluster.md
+++ b/bootstrap/openstack-cluster.md
@@ -129,8 +129,6 @@ makise   Ready    control-plane   ...   v1.35.4
 quinn    Ready    control-plane   ...   v1.35.4
 ```
 
-See [Kubernetes Bootstrap Procedure](../operating-system/kubernetes/bootstrap.md) for details on the `initKubeadm` and `joinCPKubeadm` scripts.
-
 ---
 
 ## Step 5: Install Cilium (CNI)

--- a/index.md
+++ b/index.md
@@ -23,4 +23,7 @@ features:
   - icon: 🔓
     title: Open Source First
     details: Fully open source infrastructure, ensuring transparency, flexibility, and community-driven innovation
+  - icon: 📜
+    title: Infrastructure as Code
+    details: Almost everything about the infrastructure is described as code and reconciled by FluxCD — clusters, networking, storage, the full OpenStack control plane, and tenant resources. A change is a Git commit, with no click-ops.
 ---

--- a/kubernetes/index.md
+++ b/kubernetes/index.md
@@ -1,0 +1,14 @@
+# Kubernetes
+
+The baremetal Kubernetes cluster (`openstack`) is the foundation that the entire OpenStack cloud runs on. It is deployed with `kubeadm` on the lucy, makise, and quinn nodes, with `kube-vip` providing an HA API server VIP (`10.0.0.5`) and Cilium as the CNI.
+
+## Topics
+
+- [Architecture](../operating-system/kubernetes/architecture.md) — nodes, HA VIP, and kubeadm settings.
+- [Bootstrap Procedure](../operating-system/kubernetes/bootstrap.md) — bring up the cluster with `kubeadm`.
+- [Adding a Node](../openstack/adding-a-node.md) — join a node and label it so the Yaook operators schedule OpenStack agents onto it.
+
+## Related
+
+- [GitOps → OpenStack Cluster](../gitops/fluxcd/openstack-cluster.md) — what Flux reconciles on top of this cluster.
+- [OpenStack](../openstack/) — the cloud running on this cluster.

--- a/kubernetes/index.md
+++ b/kubernetes/index.md
@@ -1,14 +1,26 @@
 # Kubernetes
 
-The baremetal Kubernetes cluster (`openstack`) is the foundation that the entire OpenStack cloud runs on. It is deployed with `kubeadm` on the lucy, makise, and quinn nodes, with `kube-vip` providing an HA API server VIP (`10.0.0.5`) and Cilium as the CNI.
+RPCU runs three types of Kubernetes clusters, each with a distinct role.
 
-## Topics
+## OpenStack Cluster (baremetal)
 
-- [Architecture](../operating-system/kubernetes/architecture.md) — nodes, HA VIP, and kubeadm settings.
-- [Bootstrap Procedure](../operating-system/kubernetes/bootstrap.md) — bring up the cluster with `kubeadm`.
-- [Adding a Node](../openstack/adding-a-node.md) — join a node and label it so the Yaook operators schedule OpenStack agents onto it.
+The foundation — a baremetal cluster (lucy, makise, quinn) that hosts the entire OpenStack control plane. Bootstrapped with kubeadm, kube-vip HA (VIP `10.0.0.5`), Cilium CNI. Not for user workloads.
 
-## Related
+- [Architecture](../operating-system/kubernetes/architecture.md)
+- [Bootstrap Procedure](../operating-system/kubernetes/bootstrap.md)
+- [Adding a Node](../openstack/adding-a-node.md)
+- [GitOps](../gitops/fluxcd/openstack-cluster.md)
 
-- [GitOps → OpenStack Cluster](../gitops/fluxcd/openstack-cluster.md) — what Flux reconciles on top of this cluster.
-- [OpenStack](../openstack/) — the cloud running on this cluster.
+## Management Cluster (CAPI)
+
+Self-managing CAPI cluster on OpenStack VMs (CAPO-provisioned). Hosts the Cluster API providers that manage itself and provision new clusters. Cannot bootstrap itself — requires a temporary kind cluster + `clusterctl move` pivot.
+
+- [Overview](../gitops/fluxcd/management-cluster.md)
+- [Bootstrap](../bootstrap/management-cluster.md)
+- [CAPI Pivot](../gitops/fluxcd/capi-pivot.md)
+
+## Workload Clusters (KaaS)
+
+Future user-facing clusters. Provisioned by the management cluster's ClusterClass (`openstack-default`) via CAPO. Runs on OpenStack VMs, designed for general user applications — not infrastructure components.
+
+To create a new workload cluster: apply a small Cluster CR referencing `openstack-default` and the management cluster handles provisioning. Templates live in [Argus](https://github.com/RPCU/argus) (`infrastructure/cluster-api-templates/`).

--- a/openstack/adding-a-node.md
+++ b/openstack/adding-a-node.md
@@ -1,0 +1,66 @@
+# Adding a Node
+
+Growing OpenStack capacity is intentionally simple. Because almost everything is described as code and reconciled by FluxCD, you do **not** edit the [Argus](https://github.com/RPCU/argus) repository to add capacity. You **join a new node to the `openstack` Kubernetes cluster and apply the right node labels** — the Yaook operators do the rest.
+
+## How it works
+
+Yaook operators schedule OpenStack agents onto Kubernetes nodes using `nodeSelectors`. When a node carries labels that an operator's selector matches, the operator automatically:
+
+- schedules the corresponding OpenStack agents onto it (`nova-compute`, the OVN `ovn-controller`),
+- registers it as a hypervisor in Nova, and
+- wires it into the OVN data plane.
+
+No re-provisioning of the control plane is required — capacity scales by labelling nodes.
+
+## Steps
+
+### 1. Join the node to the Kubernetes cluster
+
+Provision the host with NixOS (see [Operating System](../operating-system/)) and join it to the cluster. For a worker join on the baremetal OpenStack cluster, follow the same kubeadm flow used for the control plane nodes — see [Kubernetes Bootstrap](../operating-system/kubernetes/bootstrap.md).
+
+Verify it appears:
+
+```bash
+kubectl get nodes
+```
+
+### 2. Apply the node labels
+
+Label the node so the Yaook operators select it. This includes the Yaook management labels (e.g. `node.yaook.cloud/...`) plus any labels the operator `nodeSelectors` match:
+
+```bash
+kubectl label node <node-name> <label-key>=<label-value>
+```
+
+## Where the selectors live
+
+The relevant operator CRs in Argus select nodes via `nodeSelectors[].matchLabels`:
+
+- **Nova compute** — `infrastructure/yaook/nova.yaml`:
+
+  ```yaml
+  compute:
+    configTemplates:
+      - nodeSelectors:
+          - matchLabels: {}
+  ```
+
+- **OVN controller** — `infrastructure/yaook/neutron.yaml`:
+
+  ```yaml
+  setup:
+    ovn:
+      controller:
+        configTemplates:
+          - nodeSelectors:
+              - matchLabels: {}
+  ```
+
+::: info match-all default
+With the current `matchLabels: {}` (match-all), these target **every** node in the cluster — so a freshly joined node is picked up automatically once it has the Yaook management labels. To gate compute/OVN onto specific nodes, set explicit labels in these CRs and apply the matching labels to the node.
+:::
+
+## See also
+
+- [OpenStack Cluster](../gitops/fluxcd/openstack-cluster.md) — full component stack, networking, storage.
+- [OVN Bridge Configuration](../infrastructure-notes/ovn-bridge.md) — how `br-ex`/`enp3s0` is wired per node.

--- a/openstack/index.md
+++ b/openstack/index.md
@@ -1,0 +1,13 @@
+# OpenStack
+
+RPCU runs a full OpenStack cloud, deployed and operated declaratively on top of the baremetal Kubernetes cluster via [Yaook](https://yaook.cloud/) operators.
+
+## Overview
+
+The OpenStack control plane (Keystone, Glance, Nova, Neutron/OVN, Cinder, Octavia, Designate, Barbican, Horizon) runs as Kubernetes workloads on the `openstack` cluster. Everything is described as code in the [Argus](https://github.com/RPCU/argus) GitOps repository and reconciled by FluxCD — there is effectively no click-ops.
+
+For the cluster topology, networking, storage, and service routing, see [GitOps → OpenStack Cluster](../gitops/fluxcd/openstack-cluster.md).
+
+## Operations
+
+- [Adding a Node](./adding-a-node.md) — grow compute/OVN capacity by joining a node to the cluster and labelling it.

--- a/operating-system/kubernetes/bootstrap.md
+++ b/operating-system/kubernetes/bootstrap.md
@@ -2,10 +2,12 @@
 
 How to bootstrap the Kubernetes cluster on the **baremetal OpenStack nodes** using `kubeadm`. This is specifically for the production OpenStack control plane running on lucy, makise, quinn.
 
-::: tip
-For the full end-to-end workflow (OS install → kubeadm → Cilium → Flux), see the [OpenStack Cluster Bootstrap Guide](../../bootstrap/openstack-cluster.md#step-4-bootstrap-kubernetes-kubeadm).
+::: tip Canonical procedure
+The step-by-step `kubeadm` commands (`initKubeadm` / `joinCPKubeadm`) live in the end-to-end guide so the whole flow stays in one place:
 
-For the CAPI-managed management cluster, see [Management Cluster Bootstrap](../../bootstrap/management-cluster.md).
+**→ [OpenStack Cluster Bootstrap — Step 4: Bootstrap Kubernetes (kubeadm)](../../bootstrap/openstack-cluster.md#step-4-bootstrap-kubernetes-kubeadm)**
+
+This page only covers the surrounding context. For the CAPI-managed management cluster, see [Management Cluster Bootstrap](../../bootstrap/management-cluster.md).
 :::
 
 ## Prerequisites
@@ -14,42 +16,14 @@ For the CAPI-managed management cluster, see [Management Cluster Bootstrap](../.
 - SSH access to the `lucy` node (the designated bootstrap node)
 - Root privileges (`sudo`)
 
-## Bootstrap First Node (Lucy)
+## Procedure summary
 
-```bash
-ssh user@lucy
-sudo initKubeadm
-```
+1. **Initialize the first control plane (lucy)** with `sudo initKubeadm` — deploys kube-vip (VIP `10.0.0.5`), runs `kubeadm init` against the NixOS-generated config at `/etc/kubernetes/kubeadm/bootstrap.yaml`, sets up `kubectl`, and outputs the join command.
+2. **Join makise and quinn** with `sudo joinCPKubeadm <TOKEN> <CERT_KEY>`.
+3. **Verify** with `kubectl get nodes` — all three should report `Ready` / `control-plane`.
 
-The `initKubeadm` script:
-
-1. Deploys kube-vip static pods (VIP `10.0.0.5`)
-2. Runs `kubeadm init` with the pre-generated config at `/etc/kubernetes/kubeadm/bootstrap.yaml`
-3. Sets up `kubectl` for root and the calling user
-4. Outputs the join command for other control plane nodes
-
-## Join Remaining Nodes
-
-Run the output join command on makise and quinn:
-
-```bash
-# On makise
-sudo joinCPKubeadm <TOKEN> <CERT_KEY>
-
-# On quinn
-sudo joinCPKubeadm <TOKEN> <CERT_KEY>
-```
-
-## Verify
-
-```bash
-kubectl get nodes
-# NAME     STATUS   ROLES           AGE   VERSION
-# lucy     Ready    control-plane   ...   v1.35.4
-# makise   Ready    control-plane   ...   v1.35.4
-# quinn    Ready    control-plane   ...   v1.35.4
-```
+See [Step 4 of the OpenStack Cluster Bootstrap](../../bootstrap/openstack-cluster.md#step-4-bootstrap-kubernetes-kubeadm) for the exact commands and expected output.
 
 ## What's Next
 
-After kubeadm bootstrap, install Cilium (CNI) and Flux (GitOps) — see [OpenStack Cluster Bootstrap](../../bootstrap/openstack-cluster.md#step-5-install-cilium-cni).
+After kubeadm bootstrap, install Cilium (CNI) and Flux (GitOps) — see [OpenStack Cluster Bootstrap → Step 5](../../bootstrap/openstack-cluster.md#step-5-install-cilium-cni).

--- a/operating-system/kubernetes/index.md
+++ b/operating-system/kubernetes/index.md
@@ -13,9 +13,9 @@ This baremetal cluster serves a single, critical purpose: **Infrastructure as a 
 - **Hosting OpenStack:** It is designed exclusively to host the OpenStack control plane components.
 - **Not for Workloads:** This is _not_ the target environment for general user applications or services.
 
-### Future Kubernetes as a Service (KaaS)
+### Kubernetes as a Service (KaaS)
 
-Final user workloads will run on separate Kubernetes clusters deployed **as Virtual Machines** on top of the OpenStack infrastructure. These downstream clusters will be managed using [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/) with the OpenStack provider (**CAPO**), enabling a full Kubernetes-as-a-Service experience.
+See [Kubernetes → Workload Clusters](../../kubernetes/#workload-clusters-kaas).
 
 ## Architecture
 


### PR DESCRIPTION
- **docs 📚: add kubernetes and openstack documentation sections**
- **docs 📚 (kubernetes): restructure docs around three cluster types, centralize bootstrap procedure**
